### PR TITLE
Use IO#advise to inform the Kernel of what we want to do

### DIFF
--- a/lib/nessana/dump.rb
+++ b/lib/nessana/dump.rb
@@ -120,6 +120,8 @@ module Nessana
 			first_row = true
 
 			open(filename, 'rb') do |io|
+				io.advise(:willneed)
+				io.advise(:noreuse)
 				io.advise(:sequential)
 
 				FastCSV.raw_parse(io) do |row|

--- a/lib/nessana/dump.rb
+++ b/lib/nessana/dump.rb
@@ -119,24 +119,28 @@ module Nessana
 
 			first_row = true
 
-			FastCSV.foreach(filename) do |row|
-				if first_row
-					first_row = false
-					next
+			open(filename, 'rb') do |io|
+				io.advise(:sequential)
+
+				FastCSV.raw_parse(io) do |row|
+					if first_row
+						first_row = false
+						next
+					end
+
+					row_nessus_data = row[0..3] + row[7..-1]
+					row_detection_data = row[4..6]
+
+					plugin_id = row[0]
+
+					unless !!dump_data[plugin_id]
+						dump_data[plugin_id] = Vulnerability.new(*row_nessus_data)
+					end
+
+					row_detection = Detection.new(*row_detection_data)
+
+					dump_data[plugin_id].add_detection(row_detection)
 				end
-
-				row_nessus_data = row[0..3] + row[7..-1]
-				row_detection_data = row[4..6]
-
-				plugin_id = row[0]
-
-				unless !!dump_data[plugin_id]
-					dump_data[plugin_id] = Vulnerability.new(*row_nessus_data)
-				end
-
-				row_detection = Detection.new(*row_detection_data)
-
-				dump_data[plugin_id].add_detection(row_detection)
 			end
 
 			dump_data


### PR DESCRIPTION
This should help performance just a little bit as the kernel loads stuff into the page cache instead of just assuming what we want to do.  This generally works on Linux, but is up to the implementation details behind [`posix_fadvise`](http://man7.org/linux/man-pages/man2/posix_fadvise.2.html).

Seems to shave off 0.3s of load time, which is not insignificant.