### PR TITLE
Filter#applies_to?: Return false if filter key is invalid

### DIFF
--- a/lib/nessana/filter.rb
+++ b/lib/nessana/filter.rb
@@ -16,11 +16,15 @@ module Nessana
 
 		def applies_to?(vulnerability)
 			each do |key, value|
+				method = key.to_sym
+
+				return false unless vulnerability.respond_to?(method)
+
 				case value
 				when Regexp
-					return true if vulnerability.send(key.to_sym) =~ value
+					return true if vulnerability.send(method) =~ value
 				else
-					return true if vulnerability.send(key.to_sym) == value
+					return true if vulnerability.send(method) == value
 				end
 			end
 


### PR DESCRIPTION
This prevents an outright crash if you mess up a filter somewhere, and saves me time and brain.

It also makes a lot of sense; if `vulnerability` does not respond to the method you're calling, the filter clearly doesn't apply.