### PR TITLE
Remove ruby-prof as a dependency and stop using it

### DIFF
--- a/lib/nessana/executor.rb
+++ b/lib/nessana/executor.rb
@@ -1,7 +1,5 @@
 require 'optparse'
 require 'pp'
-require 'ruby-prof'
-require 'ruby-prof-flamegraph'
 
 require 'nessana/executor/execution_configuration'
 require 'nessana/filter'
@@ -15,8 +13,6 @@ module Nessana
 
 		def self.execute!(argv = ARGV)
 			parse!(*argv)
-
-			RubyProf.start if !!@configuration['performance']
 
 			unless @configuration['old_filename']
 				$stderr.puts 'No old dump filename given; will assume no prior knowledge.'
@@ -50,13 +46,6 @@ DISCOVERIES"
 					end
 				end
 				puts "\n" * 2
-			end
-
-			if !!@configuration['performance']
-				result = RubyProf.stop
-				printer = RubyProf::FlameGraphPrinter.new(result)
-				io = open(@configuration['performance'], 'wb')
-				printer.print(io, {})
 			end
 		end
 

--- a/nessana.gemspec
+++ b/nessana.gemspec
@@ -28,8 +28,6 @@ DESCRIPTION
 	s.add_development_dependency 'pry', '~> 0.12.2'
 	s.add_development_dependency 'rspec', '~> 3.7'
 	s.add_development_dependency 'rubocop', '~> 0.57'
-	s.add_development_dependency 'ruby-prof', '~> 0.17.0'
-	s.add_development_dependency 'ruby-prof-flamegraph', '~> 0.3.0'
 	s.add_development_dependency 'simplecov', '~> 0.16.1'
 
 	s.required_ruby_version = '~> 2.4'


### PR DESCRIPTION
We don't need this code in production, and any usage of it can be local-only.  (It'd be cleaner that way, anyhow.)