### PR TITLE
spec_helper: Prevent examples from stopping the rspec run early

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,3 +21,13 @@ RSpec::Matchers.define :be_requirable do
 		return true
 	end
 end
+
+RSpec.configure do |rspec|
+	rspec.around(:example) do |example|
+		begin
+			example.run
+		rescue SystemExit => e
+			fail "Got SystemExit: #{e.status}."
+		end
+	end
+end


### PR DESCRIPTION
Closes #79.

This was needed in order to stop any examples from having SystemExit errors bubble out.