### PR TITLE
travis: Force rspec to run in documentation mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ before_install:
 
 script:
   - cat config.yml.sample | tee config.yml
-  - bundle exec rspec
+  - bundle exec rspec --format documentation
 #  - bundle exec rubocop


### PR DESCRIPTION
This produces more readable and understandable output.