### PR TITLE
Executor.execute!: Print the "new" filename instead of the old one

### DIFF
--- a/lib/nessana/executor.rb
+++ b/lib/nessana/executor.rb
@@ -50,7 +50,7 @@ module Nessana
 				old_dump = Dump.new
 			end
 
-			spinner = TTY::Spinner.new("[:spinner] Loading #{@configuration['old_filename']}...", **spinner_options)
+			spinner = TTY::Spinner.new("[:spinner] Loading #{@configuration['new_filename']}...", **spinner_options)
 			spinner.auto_spin
 
 			new_dump = Dump.read(@configuration['new_filename'], filters)


### PR DESCRIPTION
This should have been done in the first place. My bad.