### PR TITLE
Executor.execute!: Stop using instance variables

### DIFF
--- a/lib/nessana/executor.rb
+++ b/lib/nessana/executor.rb
@@ -14,6 +14,7 @@ module Nessana::Executor
 	def self.execute!(argv = ARGV)
 		configuration = parse(*argv)
 
+		# TODO Don't just return whatever the value is; be more intelligent
 		return configuration unless configuration.is_a?(Nessana::Executor::ExecutionConfiguration)
 
 		return configuration['__exit-code__'] if configuration['__stop__']

--- a/lib/nessana/executor.rb
+++ b/lib/nessana/executor.rb
@@ -13,22 +13,22 @@ module Nessana
 		end
 
 		def self.execute!(argv = ARGV)
-			parse!(*argv)
+			configuration = parse(*argv)
 
-			return @configuration unless @configuration.is_a?(Nessana::Executor::ExecutionConfiguration)
+			return configuration unless configuration.is_a?(Nessana::Executor::ExecutionConfiguration)
 
-			return @configuration['__exit-code__'] if @configuration['__stop__']
+			return configuration['__exit-code__'] if configuration['__stop__']
 
-			unless @configuration['old_filename']
+			unless configuration['old_filename']
 				warn 'No old dump filename given; assuming you want this.'
 			end
 
-			unless @configuration['new_filename']
+			unless configuration['new_filename']
 				warn 'No new dump filename given; cannot do anything.'
 				return 1
 			end
 
-			filters = @configuration['filters'].map do |filter_hash|
+			filters = configuration['filters'].map do |filter_hash|
 				Filter.new(filter_hash)
 			end
 
@@ -39,21 +39,21 @@ module Nessana
 
 			old_dump = nil
 
-			if @configuration['old_filename']
-				spinner = TTY::Spinner.new("[:spinner] Loading #{@configuration['old_filename']}...", **spinner_options)
+			if configuration['old_filename']
+				spinner = TTY::Spinner.new("[:spinner] Loading #{configuration['old_filename']}...", **spinner_options)
 				spinner.auto_spin
 
-				old_dump = Dump.read(@configuration['old_filename'], filters)
+				old_dump = Dump.read(configuration['old_filename'], filters)
 
 				spinner.success('done!')
 			else
 				old_dump = Dump.new
 			end
 
-			spinner = TTY::Spinner.new("[:spinner] Loading #{@configuration['new_filename']}...", **spinner_options)
+			spinner = TTY::Spinner.new("[:spinner] Loading #{configuration['new_filename']}...", **spinner_options)
 			spinner.auto_spin
 
-			new_dump = Dump.read(@configuration['new_filename'], filters)
+			new_dump = Dump.read(configuration['new_filename'], filters)
 
 			spinner.success('done!')
 
@@ -109,12 +109,6 @@ DISCOVERIES"
 			configuration.read_configuration_file!
 
 			configuration
-		end
-
-		protected
-
-		def self.parse!(*argv)
-			@configuration = parse(*argv)
 		end
 	end
 end

--- a/lib/nessana/executor.rb
+++ b/lib/nessana/executor.rb
@@ -6,109 +6,107 @@ require 'nessana/executor/execution_configuration'
 require 'nessana/filter'
 require 'nessana/dump'
 
-module Nessana
-	module Executor
-		def self.print_usage!
-			puts @parser
+module Nessana::Executor
+	def self.print_usage!
+		puts @parser
+	end
+
+	def self.execute!(argv = ARGV)
+		configuration = parse(*argv)
+
+		return configuration unless configuration.is_a?(Nessana::Executor::ExecutionConfiguration)
+
+		return configuration['__exit-code__'] if configuration['__stop__']
+
+		unless configuration['old_filename']
+			warn 'No old dump filename given; assuming you want this.'
 		end
 
-		def self.execute!(argv = ARGV)
-			configuration = parse(*argv)
+		unless configuration['new_filename']
+			warn 'No new dump filename given; cannot do anything.'
+			return 1
+		end
 
-			return configuration unless configuration.is_a?(Nessana::Executor::ExecutionConfiguration)
+		filters = configuration['filters'].map do |filter_hash|
+			Filter.new(filter_hash)
+		end
 
-			return configuration['__exit-code__'] if configuration['__stop__']
+		spinner_options = {
+			success_mark: "\u2713".encode('utf-8'),
+			format: :dots_3
+		}
 
-			unless configuration['old_filename']
-				warn 'No old dump filename given; assuming you want this.'
-			end
+		old_dump = nil
 
-			unless configuration['new_filename']
-				warn 'No new dump filename given; cannot do anything.'
-				return 1
-			end
-
-			filters = configuration['filters'].map do |filter_hash|
-				Filter.new(filter_hash)
-			end
-
-			spinner_options = {
-				success_mark: "\u2713".encode('utf-8'),
-				format: :dots_3
-			}
-
-			old_dump = nil
-
-			if configuration['old_filename']
-				spinner = TTY::Spinner.new("[:spinner] Loading #{configuration['old_filename']}...", **spinner_options)
-				spinner.auto_spin
-
-				old_dump = Dump.read(configuration['old_filename'], filters)
-
-				spinner.success('done!')
-			else
-				old_dump = Dump.new
-			end
-
-			spinner = TTY::Spinner.new("[:spinner] Loading #{configuration['new_filename']}...", **spinner_options)
+		if configuration['old_filename']
+			spinner = TTY::Spinner.new("[:spinner] Loading #{configuration['old_filename']}...", **spinner_options)
 			spinner.auto_spin
 
-			new_dump = Dump.read(configuration['new_filename'], filters)
+			old_dump = Dump.read(configuration['old_filename'], filters)
 
 			spinner.success('done!')
+		else
+			old_dump = Dump.new
+		end
 
-			spinner = TTY::Spinner.new('[:spinner] Comparing dumps...', **spinner_options)
-			spinner.auto_spin
+		spinner = TTY::Spinner.new("[:spinner] Loading #{configuration['new_filename']}...", **spinner_options)
+		spinner.auto_spin
 
-			diff = new_dump - old_dump
+		new_dump = Dump.read(configuration['new_filename'], filters)
 
-			spinner.success('done!')
+		spinner.success('done!')
 
-			diff.sort do |vulnerability_a, vulnerability_b|
-				vulnerability_a.plugin_id.to_i <=> vulnerability_b.plugin_id.to_i
-			end.sort do |vulnerability_a, vulnerability_b|
-				vulnerability_a.cvss.to_f <=> vulnerability_b.cvss.to_f
-			end.each do |v|
-				puts "#{v}
+		spinner = TTY::Spinner.new('[:spinner] Comparing dumps...', **spinner_options)
+		spinner.auto_spin
+
+		diff = new_dump - old_dump
+
+		spinner.success('done!')
+
+		diff.sort do |vulnerability_a, vulnerability_b|
+			vulnerability_a.plugin_id.to_i <=> vulnerability_b.plugin_id.to_i
+		end.sort do |vulnerability_a, vulnerability_b|
+			vulnerability_a.cvss.to_f <=> vulnerability_b.cvss.to_f
+		end.each do |v|
+			puts "#{v}
 
 DISCOVERIES"
-				v.detections.sort_by(&:port).sort_by(&:host).each do |detection|
-					if detection.status && detection.status != true
-						puts detection.to_s
-					end
-				end
-				puts "\n" * 2
-			end
-
-			0
-		end
-
-		def self.parse(*argv)
-			configuration = ExecutionConfiguration.new
-
-			option_parser = OptionParser.new do |parser|
-				configuration.add_parser_hooks(parser)
-
-				if argv.count == 0
-					puts parser
-					return 1
+			v.detections.sort_by(&:port).sort_by(&:host).each do |detection|
+				if detection.status && detection.status != true
+					puts detection.to_s
 				end
 			end
-
-			remaining_arguments = option_parser.order!(argv)
-
-			case remaining_arguments.count
-			when 2
-				configuration['old_filename'] = remaining_arguments[0]
-				configuration['new_filename'] = remaining_arguments[1]
-			when 1
-				configuration['old_filename'] = nil
-				configuration['new_filename'] = remaining_arguments[0]
-			end
-
-			configuration.read_configuration_file!
-
-			configuration
+			puts "\n" * 2
 		end
+
+		0
+	end
+
+	def self.parse(*argv)
+		configuration = ExecutionConfiguration.new
+
+		option_parser = OptionParser.new do |parser|
+			configuration.add_parser_hooks(parser)
+
+			if argv.count == 0
+				puts parser
+				return 1
+			end
+		end
+
+		remaining_arguments = option_parser.order!(argv)
+
+		case remaining_arguments.count
+		when 2
+			configuration['old_filename'] = remaining_arguments[0]
+			configuration['new_filename'] = remaining_arguments[1]
+		when 1
+			configuration['old_filename'] = nil
+			configuration['new_filename'] = remaining_arguments[0]
+		end
+
+		configuration.read_configuration_file!
+
+		configuration
 	end
 end

--- a/spec/lib/nessana/executor_spec.rb
+++ b/spec/lib/nessana/executor_spec.rb
@@ -23,7 +23,7 @@ describe Nessana do
 				allow(STDOUT).to receive(:write)
 			end
 
-			context 'if .parse returns non-ExecutionConfiguration' do
+			context 'with a non-ExecutionConfiguration configuration' do
 				it 'returns the result from .parse' do
 					allow(subject).to receive(:parse) { 2 }
 					expect(subject.send(:execute!)).to eq(2)

--- a/spec/lib/nessana/executor_spec.rb
+++ b/spec/lib/nessana/executor_spec.rb
@@ -56,6 +56,20 @@ describe Nessana do
 				end
 			end
 
+			context 'with a configuration with new_filename not present' do
+				it 'warns' do
+					allow(subject).to receive(:parse) do
+						configuration = Nessana::Executor::ExecutionConfiguration.new
+						configuration['new_filename'] = nil
+						configuration
+					end
+
+					expect(subject).to receive(:warn)
+					expect { subject.send(:execute!) }.not_to raise_error
+					expect(subject.send(:execute!)).to eq(1)
+				end
+			end
+
 			context 'taking no command-line arguments' do
 				let(:arguments) { [] }
 

--- a/spec/lib/nessana/executor_spec.rb
+++ b/spec/lib/nessana/executor_spec.rb
@@ -43,6 +43,19 @@ describe Nessana do
 				end
 			end
 
+			context 'with a configuration with old_filename not present' do
+				it 'warns' do
+					allow(subject).to receive(:parse) do
+						configuration = Nessana::Executor::ExecutionConfiguration.new
+						configuration['old_filename'] = nil
+						configuration
+					end
+
+					expect(subject).to receive(:warn)
+					expect { subject.send(:execute!) }.not_to raise_error
+				end
+			end
+
 			context 'taking no command-line arguments' do
 				let(:arguments) { [] }
 

--- a/spec/lib/nessana/executor_spec.rb
+++ b/spec/lib/nessana/executor_spec.rb
@@ -30,6 +30,19 @@ describe Nessana do
 				end
 			end
 
+			context 'with a configuration with __stop__ set' do
+				it 'returns the value of ExecutionConfiguration' do
+					allow(subject).to receive(:parse) do
+						configuration = Nessana::Executor::ExecutionConfiguration.new
+						configuration['__stop__'] = true
+						configuration['__exit-code__'] = 7
+						configuration
+					end
+
+					expect(subject.send(:execute!)).to eq(7)
+				end
+			end
+
 			context 'taking no command-line arguments' do
 				let(:arguments) { [] }
 

--- a/spec/lib/nessana/executor_spec.rb
+++ b/spec/lib/nessana/executor_spec.rb
@@ -23,6 +23,13 @@ describe Nessana do
 				allow(STDOUT).to receive(:write)
 			end
 
+			context 'if .parse returns non-ExecutionConfiguration' do
+				it 'returns the result from .parse' do
+					allow(subject).to receive(:parse) { 2 }
+					expect(subject.send(:execute!)).to eq(2)
+				end
+			end
+
 			context 'taking no command-line arguments' do
 				let(:arguments) { [] }
 


### PR DESCRIPTION
Instead, use a real variable like `configuration`. Instance variables on modules are strange.